### PR TITLE
Add auto-fetcher entry point and fix YouTube rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Convert YouTube transcripts to structured XML format with automatic chapter dete
 
 **Prerequisites:** [Install UV](https://docs.astral.sh/uv/getting-started/installation/) first.
 
-### Option 1: Automated (Recommended)
+### Option 1: Automated (Experimental)
+
+> [!NOTE]  
+> This approach uses a local development environment. You'll clone the repo and run the experimental script directly.
 
 Get YouTube transcripts directly from URL:
 
@@ -20,7 +23,7 @@ Get YouTube transcripts directly from URL:
 git clone https://github.com/michellepace/youtube-to-xml.git
 cd youtube-to-xml
 uv sync
-uv run scripts/transcript_auto_fetcher.py https://youtu.be/Q4gsvJvRjCU
+uv run transcript-auto-fetcher https://youtu.be/Q4gsvJvRjCU
 ```
 
 **Output:**
@@ -33,7 +36,7 @@ uv run scripts/transcript_auto_fetcher.py https://youtu.be/Q4gsvJvRjCU
    Parsed 75 subtitles
 📑 Organising into 4 chapter(s)...
 🔧 Building XML document...
-✅ Saved to: how-claude-code-hooks-save-me-hours-daily.xml
+✅ Created: /home/mp/projects/python/youtube-to-xml/how-claude-code-hooks-save-me-hours-daily.xml
 ```
 
 **Features:**
@@ -45,10 +48,13 @@ uv run scripts/transcript_auto_fetcher.py https://youtu.be/Q4gsvJvRjCU
 
 ### Option 2: Manual Method (Current CLI)
 
+> [!TIP]  
+> This installs the tool globally on your system. You can use `youtube-to-xml` from any directory after installation.
+
 For manual transcript processing:
 
 ```bash
-# Install CLI tool
+# Install CLI tool globally
 uv tool install git+https://github.com/michellepace/youtube-to-xml.git
 
 # Manually copy YouTube transcript into my_transcript.txt, then:
@@ -98,8 +104,8 @@ uv sync
 
 **Testing:**
 ```bash
-uv run python -m pytest          # All tests
-uv run python -m pytest -v       # Verbose output
+uv run pytest                    # All tests
+uv run pytest -v                 # Verbose output
 ```
 
 **Code Quality:**
@@ -117,7 +123,7 @@ Built with Test-Driven Development using:
 - **CLI**: Argparse with comprehensive error handling
 - **Architecture**: Pure functions with clear module separation
 - **Dependencies**:
-  - Runtime Dependencies: `yt_dlp` (fetch transcript and metadata from YouTube URL). This is currently used by [scrpits/transcript_auto_fetcher.py](scrpits/transcript_auto_fetcher.py) only.
+  - Runtime Dependencies: `yt_dlp` (fetch transcript and metadata from YouTube URL). This is currently used by the experimental [scripts/transcript_auto_fetcher.py](scripts/transcript_auto_fetcher.py) only.
   - Dev Dependencies: `pytest`, `ruff`, `pre-commit`
 - **Package Management**: UV Package Application
 
@@ -142,4 +148,4 @@ Performance tested with transcripts up to 15,000 lines completing in 0.02 second
 **To Do**
 1. Evals to prove XML format vs plain (myself here, then Braintrust)
 2. If so, improve XML perhaps to [this](docs/misc/working-notes.md#better-format). I don't think so, disjoint.
-3. Refactor [src/](src/) and [tests/](tests/) to automatically get transcript from YouTube URL as per experimental script [scripts/transcript_auto_fetcher.py](scripts/transcript_auto_fetcher.py).
+3. Integrate experimental [scripts/transcript_auto_fetcher.py](scripts/transcript_auto_fetcher.py) functionality into main CLI, then remove the standalone script.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,43 +1,69 @@
-[project]
-name = "youtube-to-xml"
-version = "0.1.0"
-description = "Add your description here"
-readme = "README.md"
-authors = [
-    { name = "Michelle", email = "" }
-]
-requires-python = ">=3.13"
-dependencies = [
-    "yt-dlp>=2025.8.11",
-]
-
-[project.scripts]
-youtube-to-xml = "youtube_to_xml.cli:main"
+# ============================================================================
+# Build System
+# ============================================================================
 
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]
 build-backend = "uv_build"
 
+
+# ============================================================================
+# Project Metadata & Dependencies
+# ============================================================================
+
+[project]
+name = "youtube-to-xml"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+authors = [ { name = "Michelle", email = "" } ]
+
+requires-python = ">=3.13"
+
+dependencies = [
+    "yt-dlp>=2025.8.27",
+]
+
+# Entry points
+[project.scripts]
+youtube-to-xml = "youtube_to_xml.cli:main"
+transcript-auto-fetcher = "youtube_to_xml.transcript_auto_fetcher_wrapper:main" # experimental
+
+
+# ============================================================================
+# Development Dependencies
+# ============================================================================
+
 [dependency-groups]
 dev = [
     "pre-commit>=4.2.0",
     "pytest>=8.4.1",
-    "ruff>=0.12.7",
+    "ruff>=0.12.11",
 ]
+
+
+# ============================================================================
+# Development Tools Configuration
+# ============================================================================
 
 [tool.pyright]
 # Type Checker is needed as Ruff is only a linter: https://docs.astral.sh/ruff/faq/
 # For Cursor (Cursor Pyright extension), for VSCode (Microsoft Pylance)
 # Cursor Pyright forks BasedPyright, some lint rules overlap with Ruff, causes dupe errors
 
-# CP default
+# Cursor Pyright default
 typeCheckingMode = "standard"
 
-# Disable Basedpyright rules that dupe Ruff
+# Disable Basedpyright rules that duplicate Ruff
 reportUnusedImport = false      # Ruff F401 handles it
 reportUnusedVariable = false    # Ruff F841 handles it
 reportDuplicateImport = false   # Ruff F811 handles it
 reportUnusedParameter = false   # Ruff ARG001 handles it
+
+
+# ============================================================================
+# Ruff Linter Configuration
+# ============================================================================
 
 [tool.ruff]
 # Strictest ruff settings
@@ -58,6 +84,18 @@ ignore = [
     "T201",    # Print found (allow print statements)
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.pylint]
+max-args = 5
+max-branches = 12
+max-returns = 6
+max-statements = 50
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
     "D103",    # Missing docstring in public function  
@@ -73,15 +111,3 @@ ignore = [
     "TRY400",  # Use logger.error for handled user errors (not exceptions needing traceback)
     "TRY401",  # Exception object in logging.exception is intentional for context
 ]
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
-
-[tool.ruff.lint.pylint]
-max-args = 5
-max-branches = 12
-max-returns = 6
-max-statements = 50
-
-[tool.ruff.lint.mccabe]
-max-complexity = 10

--- a/src/youtube_to_xml/transcript_auto_fetcher_wrapper.py
+++ b/src/youtube_to_xml/transcript_auto_fetcher_wrapper.py
@@ -1,0 +1,30 @@
+"""Wrapper to run the experimental transcript auto fetcher script as an entry point.
+
+This wrapper exists to:
+- Enable easier script execution: `uv run transcript-auto-fetcher` vs long path
+- Simplify integration test commands in tests/test_integration.py
+
+TODO: When experimental scripts/transcript_auto_fetcher.py is integrated and deleted:
+- Remove this wrapper file
+- Remove 'transcript-auto-fetcher' entry point from pyproject.toml
+- Update integration tests to use main CLI instead
+"""
+
+import sys
+from pathlib import Path
+
+# Add the project root to Python path so we can import the script
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import after path setup to avoid import errors
+from scripts.transcript_auto_fetcher import main as script_main  # noqa: E402
+
+
+def main() -> None:
+    """Entry point wrapper for transcript_auto_fetcher script."""
+    script_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,17 +1,12 @@
 """Integration tests for end-to-end validation of CLI and YouTube fetcher."""
 
 import subprocess
-import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
 
-# Import from script for direct function testing
-sys.path.insert(0, str(Path.cwd() / "scripts"))
-
 # Test constants
-SCRIPT_PATH = Path.cwd() / "scripts/transcript_auto_fetcher.py"
 EXAMPLES_DIR = Path("example_transcripts")
 URL_CHAPTERS = "https://www.youtube.com/watch?v=Q4gsvJvRjCU"
 URL_CHAPTERS_SHARED = "https://youtu.be/Q4gsvJvRjCU?si=8cEkF7OrXrB1R4d7&t=27"
@@ -36,7 +31,7 @@ def run_cli_command(args: list[str], tmp_path: Path) -> subprocess.CompletedProc
 def run_youtube_script(url: str, tmp_path: Path) -> subprocess.CompletedProcess:
     """Run YouTube script with rate limit handling."""
     result = subprocess.run(  # noqa: S603
-        ["uv", "run", "python", str(SCRIPT_PATH), url],
+        ["uv", "run", "transcript-auto-fetcher", url],
         capture_output=True,
         text=True,
         cwd=tmp_path,

--- a/uv.lock
+++ b/uv.lock
@@ -206,13 +206,13 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "yt-dlp", specifier = ">=2025.8.11" }]
+requires-dist = [{ name = "yt-dlp", specifier = ">=2025.8.27" }]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.1" },
-    { name = "ruff", specifier = ">=0.12.7" },
+    { name = "ruff", specifier = ">=0.12.11" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Creates proper entry point for experimental auto-fetcher script (`uv run transcript-auto-fetcher`)
- Upgrades yt-dlp to resolve YouTube rate limiting issues in older versions
- Reorganizes pyproject.toml structure for better maintainability

## Test plan
- [x] All existing tests pass (verified by pre-commit hooks)
- [x] Integration tests updated to use new entry point
- [x] Entry point accessible via `uv run transcript-auto-fetcher`
- [x] YouTube rate limiting resolved with yt-dlp upgrade

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an experimental CLI: transcript-auto-fetcher, installable globally and runnable from anywhere.

- Documentation
  - Updated README: marks “Automated” option as Experimental, adds global CLI usage tips, refines output wording, updates commands and paths, and revises TODOs.

- Tests
  - Integration tests now invoke the transcript-auto-fetcher via CLI instead of direct script execution.

- Chores
  - Updated dependencies (yt-dlp, Ruff) and restructured lint/tooling configuration, including target Python version and per-file lint ignores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->