### PR TITLE
refactor: centralise time formatting utilities and update XML attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ First, we'll start with the patches
 **Output XML:**
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
-<transcript video_title="" upload_date="" duration="" video_url="">
+<transcript video_title="" video_published="" video_duration="" video_url="">
   <chapters>
     <chapter title="Introduction to Cows" start_time="0:02">
       0:02
@@ -72,8 +72,8 @@ url-to-transcript https://youtu.be/Q4gsvJvRjCU
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
 <transcript video_title="How Claude Code Hooks Save Me HOURS Daily" 
-            upload_date="2025-07-12" 
-            duration="2m 43s" 
+            video_published="2025-07-12" 
+            video_duration="2m 43s" 
             video_url="https://www.youtube.com/watch?v=Q4gsvJvRjCU">
   <chapters>
     <chapter title="Intro" start_time="0:00">
@@ -105,7 +105,7 @@ url-to-transcript https://youtu.be/Q4gsvJvRjCU
 
 **Architecture**: Pure functions with clear module separation
 
-**Test-Driven Development**: 74 tests (17 integration, 57 unit, takes 62 seconds)
+**Test-Driven Development**: 78 tests (17 integration, 61 unit, takes 59 seconds)
 
 **Dependencies**:
 - Runtime Dependencies: `yt-dlp` (fetch metadata and download transcript from YouTube URL)

--- a/example_transcripts/how-claude-code-hooks-save-me-hours-daily.txt.xml
+++ b/example_transcripts/how-claude-code-hooks-save-me-hours-daily.txt.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<transcript video_title="" upload_date="" duration="" video_url="">
+<transcript video_title="" video_published="" video_duration="" video_url="">
   <chapters>
     <chapter title="Intro" start_time="0:00">
       0:00

--- a/example_transcripts/how-claude-code-hooks-save-me-hours-daily.xml
+++ b/example_transcripts/how-claude-code-hooks-save-me-hours-daily.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<transcript video_title="How Claude Code Hooks Save Me HOURS Daily" upload_date="2025-07-12" duration="2m 43s" video_url="https://www.youtube.com/watch?v=Q4gsvJvRjCU">
+<transcript video_title="How Claude Code Hooks Save Me HOURS Daily" video_published="2025-07-12" video_duration="2m 43s" video_url="https://www.youtube.com/watch?v=Q4gsvJvRjCU">
   <chapters>
     <chapter title="Intro" start_time="0:00">
       0:00

--- a/example_transcripts/introduction-to-cows.xml
+++ b/example_transcripts/introduction-to-cows.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<transcript video_title="" upload_date="" duration="" video_url="">
+<transcript video_title="" video_published="" video_duration="" video_url="">
   <chapters>
     <chapter title="Introduction to Cows" start_time="0:02">
       0:02

--- a/example_transcripts/pick-up-where-you-left-off-with-claude.xml
+++ b/example_transcripts/pick-up-where-you-left-off-with-claude.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<transcript video_title="Pick up where you left off with Claude" upload_date="2025-08-11" duration="35s" video_url="https://www.youtube.com/watch?v=UdoY2l5TZaA">
+<transcript video_title="Pick up where you left off with Claude" video_published="2025-08-11" video_duration="35s" video_url="https://www.youtube.com/watch?v=UdoY2l5TZaA">
   <chapters>
     <chapter title="Pick up where you left off with Claude" start_time="0:00">
       0:06

--- a/example_transcripts/x3-chapters-with-blanks.xml
+++ b/example_transcripts/x3-chapters-with-blanks.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<transcript video_title="" upload_date="" duration="" video_url="">
+<transcript video_title="" video_published="" video_duration="" video_url="">
   <chapters>
     <chapter title="Chapter 1" start_time="0:01">
       0:01

--- a/example_transcripts/x4-chapters.xml
+++ b/example_transcripts/x4-chapters.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<transcript video_title="" upload_date="" duration="" video_url="">
+<transcript video_title="" video_published="" video_duration="" video_url="">
   <chapters>
     <chapter title="Intro" start_time="0:00">
       0:00

--- a/scripts/url_to_transcript.py
+++ b/scripts/url_to_transcript.py
@@ -12,7 +12,7 @@ Example:
     uv run scripts/url_to_transcript.py https://youtu.be/Q4gsvJvRjCU
 
 For a provided YouTube URL, the script will:
-1. Fetch the video metadata (title, upload date, duration)
+1. Fetch the video metadata (title, published date, duration)
 2. Download and parse transcript lines (the timestamped text from YouTube's transcript)
 3. Assign transcript lines to chapters (using YouTube's chapter markers if available)
 4. Create and save an XML document with dynamic filename based on video title
@@ -22,9 +22,9 @@ Transcript priority:
 2. Auto-generated English transcript (fallback)
 No other languages are downloaded - English only.
 
-The output XML contains video metadata (video_title, upload_date, duration, video_url)
-and transcript lines organised by chapter, with each individual transcript line
-timestamped.
+The output XML contains video metadata (video_title, video_published,
+video_duration, video_url) and transcript lines organised by chapter, with each
+individual transcript line timestamped.
 """
 
 import contextlib
@@ -57,7 +57,7 @@ from youtube_to_xml.logging_config import get_logger, setup_logging
 from youtube_to_xml.time_utils import (
     MILLISECONDS_PER_SECOND,
     format_video_duration,
-    format_video_upload_date,
+    format_video_published,
     seconds_to_timestamp,
 )
 
@@ -70,8 +70,8 @@ class VideoMetadata:
     """Video metadata needed for XML output."""
 
     video_title: str
-    upload_date: str  # YYYY-MM-DD formatted string
-    duration: str  # "2m 43s" formatted string
+    video_published: str  # YYYY-MM-DD formatted string
+    video_duration: str  # "2m 43s" formatted string
     video_url: str
     chapters_data: list[dict]
 
@@ -192,8 +192,8 @@ def fetch_video_metadata_and_transcript(
         # Phase 3: Create structured metadata object from raw_metadata
         metadata = VideoMetadata(
             video_title=raw_metadata.get("title", "Untitled"),
-            upload_date=format_video_upload_date(raw_metadata.get("upload_date", "")),
-            duration=format_video_duration(float(raw_metadata.get("duration", 0))),
+            video_published=format_video_published(raw_metadata.get("upload_date", "")),
+            video_duration=format_video_duration(float(raw_metadata.get("duration", 0))),
             video_url=raw_metadata.get("webpage_url", url),
             chapters_data=raw_metadata.get("chapters", []),
         )
@@ -298,8 +298,8 @@ def create_xml_document(metadata: VideoMetadata, chapters: list[Chapter]) -> str
     # Create root element with metadata attributes
     root = ET.Element("transcript")
     root.set("video_title", metadata.video_title)
-    root.set("upload_date", metadata.upload_date)
-    root.set("duration", metadata.duration)
+    root.set("video_published", metadata.video_published)
+    root.set("video_duration", metadata.video_duration)
     root.set("video_url", metadata.video_url)
 
     # Add chapters container

--- a/src/youtube_to_xml/time_utils.py
+++ b/src/youtube_to_xml/time_utils.py
@@ -96,10 +96,10 @@ def seconds_to_timestamp(seconds: float) -> str:
 
 
 def format_video_published(date_string: str) -> str:
-    """Convert YYYYMMDD to yyyy-mm-dd format."""
+    """Convert YYYYMMDD to YYYY-MM-DD format."""
     if len(date_string) == len("20250101"):
         try:
-            date = datetime.strptime(date_string, "%Y%m%d").replace(tzinfo=None)  # noqa: DTZ007
+            date = datetime.strptime(date_string, "%Y%m%d")  # noqa: DTZ007
             return date.strftime("%Y-%m-%d")
         except ValueError:
             return date_string
@@ -108,7 +108,7 @@ def format_video_published(date_string: str) -> str:
 
 def format_video_duration(seconds: float) -> str:
     """Convert seconds to human-readable duration e.g., "1h 5m 12s"."""
-    if seconds <= 0:
+    if not math.isfinite(seconds) or seconds <= 0:
         return ""
 
     total_seconds = int(seconds)

--- a/src/youtube_to_xml/time_utils.py
+++ b/src/youtube_to_xml/time_utils.py
@@ -95,7 +95,7 @@ def seconds_to_timestamp(seconds: float) -> str:
     return f"{minutes}:{secs:02d}"
 
 
-def format_video_upload_date(date_string: str) -> str:
+def format_video_published(date_string: str) -> str:
     """Convert YYYYMMDD to yyyy-mm-dd format."""
     if len(date_string) == len("20250101"):
         try:

--- a/src/youtube_to_xml/time_utils.py
+++ b/src/youtube_to_xml/time_utils.py
@@ -6,6 +6,7 @@ Used by both file parser and URL-based transcript processors.
 
 import math
 import re
+from datetime import datetime
 
 from youtube_to_xml.exceptions import FileInvalidFormatError
 
@@ -92,3 +93,35 @@ def seconds_to_timestamp(seconds: float) -> str:
     if hours > 0:
         return f"{hours}:{minutes:02d}:{secs:02d}"
     return f"{minutes}:{secs:02d}"
+
+
+def format_video_upload_date(date_string: str) -> str:
+    """Convert YYYYMMDD to yyyy-mm-dd format."""
+    if len(date_string) == len("20250101"):
+        try:
+            date = datetime.strptime(date_string, "%Y%m%d").replace(tzinfo=None)  # noqa: DTZ007
+            return date.strftime("%Y-%m-%d")
+        except ValueError:
+            return date_string
+    return date_string
+
+
+def format_video_duration(seconds: float) -> str:
+    """Convert seconds to human-readable duration e.g., "1h 5m 12s"."""
+    if seconds <= 0:
+        return ""
+
+    total_seconds = int(seconds)
+
+    hours, remainder = divmod(total_seconds, SECONDS_PER_HOUR)
+    minutes, secs = divmod(remainder, SECONDS_PER_MINUTE)
+
+    parts = []
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if minutes > 0:
+        parts.append(f"{minutes}m")
+    if secs > 0 or not parts:
+        parts.append(f"{secs}s")
+
+    return " ".join(parts)

--- a/src/youtube_to_xml/xml_builder.py
+++ b/src/youtube_to_xml/xml_builder.py
@@ -14,8 +14,8 @@ def chapters_to_xml(chapters: list[Chapter]) -> str:
     # Create root XML tag element <transcript>
     root = ET.Element("transcript")
     root.set("video_title", "")
-    root.set("upload_date", "")
-    root.set("duration", "")
+    root.set("video_published", "")
+    root.set("video_duration", "")
     root.set("video_url", "")
 
     # Add XML container tag element <chapters>

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -216,7 +216,7 @@ def test_url_vs_file_equivalent_output(tmp_path: Path) -> None:
     assert file_lines == url_lines, "Line count must be the same"
 
     # 2. Assert transcript element attributes
-    expected_attrs = ["video_title", "upload_date", "duration", "video_url"]
+    expected_attrs = ["video_title", "video_published", "video_duration", "video_url"]
 
     # File transcript should have empty metadata
     assert len(file_root.attrib) == 4, (

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -74,17 +74,11 @@ def test_seconds_to_timestamp_rejects_negative_values() -> None:
     with pytest.raises(ValueError, match="seconds must be finite and >= 0"):
         seconds_to_timestamp(-1.0)
 
-    with pytest.raises(ValueError, match="seconds must be finite and >= 0"):
-        seconds_to_timestamp(-0.1)
-
 
 def test_seconds_to_timestamp_rejects_infinite_values() -> None:
     """Test that infinite values raise ValueError."""
     with pytest.raises(ValueError, match="seconds must be finite and >= 0"):
         seconds_to_timestamp(math.inf)
-
-    with pytest.raises(ValueError, match="seconds must be finite and >= 0"):
-        seconds_to_timestamp(-math.inf)
 
 
 def test_seconds_to_timestamp_rejects_nan_values() -> None:
@@ -147,7 +141,6 @@ def test_format_video_published_invalid_format_passthrough() -> None:
 def test_format_video_duration_seconds_to_human() -> None:
     """Test conversion from seconds to human-readable duration."""
     # Basic conversions
-    assert format_video_duration(0) == ""
     assert format_video_duration(1) == "1s"
     assert format_video_duration(59) == "59s"
     assert format_video_duration(60) == "1m"
@@ -161,8 +154,12 @@ def test_format_video_duration_seconds_to_human() -> None:
     assert format_video_duration(3661.9) == "1h 1m 1s"
 
 
-def test_format_video_duration_invalid_format_passthrough() -> None:
-    """Test that zero and negative durations return empty string."""
-    assert format_video_duration(-0.5) == ""
+def test_format_video_duration_non_positive_returns_empty() -> None:
+    """Zero and negative durations return empty string."""
+    assert format_video_duration(0) == ""
     assert format_video_duration(-1) == ""
-    assert format_video_duration(-100) == ""
+
+
+def test_format_video_duration_non_finite_returns_empty() -> None:
+    """Non-finite values return empty string."""
+    assert format_video_duration(math.inf) == ""

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -11,7 +11,7 @@ from youtube_to_xml.exceptions import FileInvalidFormatError
 from youtube_to_xml.time_utils import (
     TIMESTAMP_PATTERN,
     format_video_duration,
-    format_video_upload_date,
+    format_video_published,
     seconds_to_timestamp,
     timestamp_to_seconds,
 )
@@ -127,21 +127,21 @@ def test_timestamp_pattern_rejects_invalid_formats() -> None:
         assert not TIMESTAMP_PATTERN.match(timestamp), f"Should not match: {timestamp}"
 
 
-def test_format_video_upload_date_yyyymmdd_to_iso() -> None:
+def test_format_video_published_yyyymmdd_to_iso() -> None:
     """Test conversion from YYYYMMDD to YYYY-MM-DD format."""
-    assert format_video_upload_date("") == ""
-    assert format_video_upload_date("20250101") == "2025-01-01"
-    assert format_video_upload_date("19991231") == "1999-12-31"
-    assert format_video_upload_date("20240229") == "2024-02-29"  # leap year
+    assert format_video_published("") == ""
+    assert format_video_published("20250101") == "2025-01-01"
+    assert format_video_published("19991231") == "1999-12-31"
+    assert format_video_published("20240229") == "2024-02-29"  # leap year
 
 
-def test_format_video_upload_date_invalid_format_passthrough() -> None:
+def test_format_video_published_invalid_format_passthrough() -> None:
     """Test that invalid date formats pass through unchanged."""
-    assert format_video_upload_date("2025-01-01") == "2025-01-01"  # already formatted
-    assert format_video_upload_date("not-a-date") == "not-a-date"
-    assert format_video_upload_date("202501") == "202501"  # too short
-    assert format_video_upload_date("2025013100") == "2025013100"  # too long
-    assert format_video_upload_date("20251301") == "20251301"  # invalid month
+    assert format_video_published("2025-01-01") == "2025-01-01"  # already formatted
+    assert format_video_published("not-a-date") == "not-a-date"
+    assert format_video_published("202501") == "202501"  # too short
+    assert format_video_published("2025013100") == "2025013100"  # too long
+    assert format_video_published("20251301") == "20251301"  # invalid month
 
 
 def test_format_video_duration_seconds_to_human() -> None:

--- a/xNEXT.md
+++ b/xNEXT.md
@@ -1,0 +1,287 @@
+# Integration Analysis Report: YouTube Transcript to XML Converter
+
+## Executive Summary
+
+I recommend a **phased integration approach using structured data models**. The strategy prioritizes TranscriptLine objects for type safety and source-agnostic processing, while maintaining 100% backward compatibility. The integration will be delivered through 3 focused PRs, each providing immediate testable and integrated value.
+
+## 1. Current State Analysis
+
+### Architecture Overview
+
+The application currently has two separate implementations:
+
+1. **FILE-based method** (`src/youtube_to_xml/file_parser.py`)
+   - Parses manually-created transcript text files
+   - Produces XML with empty metadata attributes (`video_title=""`)
+   - Uses `Chapter` with `transcript_lines: list[str]` (raw strings with embedded timestamps)
+   - Tightly coupled with `xml_builder.py`
+
+2. **URL-based method** (`scripts/url_to_transcript.py`)
+   - Fetches transcripts directly from YouTube via yt-dlp
+   - Produces XML with full metadata attributes
+   - Uses `Chapter` with `transcript_lines: list[TranscriptLine]` (structured objects)
+   - Contains duplicate XML generation logic
+
+### Key Findings
+
+#### Critical Incompatibility
+
+The fundamental issue is the **transcript line representation**:
+- FILE: `"0:03\nWelcome to the talk"` (single string with embedded timestamp)
+- URL: `TranscriptLine(timestamp=3.0, text="Welcome to the talk")` (structured object)
+
+This difference prevents code reuse and violates DRY principles.
+
+#### Shared Functionality Scattered
+
+Time/date formatting functions are duplicated or scattered:
+- `format_video_published()` and `format_video_duration()` only in URL script
+- `seconds_to_timestamp()` in time_utils but needed by both
+- Tight coupling between `file_parser.py` and `xml_builder.py`
+
+## 2. Investigation Results
+
+### Why Structured TranscriptLine Objects?
+
+Per `docs/terminology.md`, transcript lines are defined as timestamp + text pairs, which aligns perfectly with structured objects:
+
+**Advantages of TranscriptLine approach:**
+- **Type safety**: Prevents accidental timestamp/content confusion
+- **Source-agnostic**: Both parsers produce identical structured output
+- **Future-proof**: Easy to add fields (speaker, confidence scores)
+- **Clean separation**: Data structure matches conceptual model
+
+### Data Storage vs Presentation
+
+**Decision**: Store raw data, format at display time
+- VideoMetadata stores: `video_duration: int` (seconds), `video_published: str` (YYYYMMDD)
+- xml_builder handles all formatting for consistency
+- Maintains separation of concerns
+
+**Important Duration Handling:**
+- File method: Sets `video_duration = 0` (integer zero)
+- URL method: Sets `video_duration = <seconds>` from YouTube metadata
+- XML output: `video_duration=""` when 0, `video_duration="2h 15m"` when > 0
+- This preserves backward compatibility while enabling rich metadata
+
+## 3. Architectural Plan for Integration
+
+### High-Level Design
+
+```
+                    ┌─────────────────────┐
+                    │     models.py       │
+                    │  ┌───────────────┐  │
+                    │  │ VideoMetadata │  │
+                    │  │ TranscriptLine│  │
+                    │  │ Chapter       │  │
+                    │  └───────────────┘  │
+                    └──────────┬──────────┘
+                               │
+                    ┌──────────┴──────────┐
+                    │                     │
+           ┌────────▼────────┐  ┌────────▼────────┐
+           │ file_parser.py  │  │ url_parser.py   │
+           │                 │  │    (new)        │
+           │ Parses text     │  │ Fetches from    │
+           │ files into      │  │ YouTube into    │
+           │ Chapter objects │  │ Chapter objects │
+           └────────┬────────┘  └─────────┬───────┘
+                    │                     │
+                    │  ┌──────────────┐   │
+                    └─▶│ xml_builder  │◀─┘
+                       │              │
+                       │ Converts     │
+                       │ Chapters +   │
+                       │ Metadata     │
+                       │ to XML       │
+                       └──────┬───────┘
+                              │
+                    ┌─────────▼─────────┐
+                    │      cli.py       │
+                    │                   │
+                    │ Orchestrates      │
+                    │ file/url flows    │
+                    └───────────────────┘
+                              │
+                              ▼
+                        XML Output
+```
+
+### Shared Modules
+
+1. **`models.py`**: Unified data structures
+   ```python
+   @dataclass
+   class VideoMetadata:
+       video_title: str = ""
+       video_published: str = ""  # YYYYMMDD raw format or empty
+       video_duration: int = 0      # seconds (0 for file method)
+       video_url: str = ""
+
+   @dataclass
+   class TranscriptLine:
+       timestamp: float  # seconds
+       text: str
+
+   @dataclass
+   class Chapter:
+       title: str
+       start_time: float
+       end_time: float
+       transcript_lines: list[TranscriptLine]
+   ```
+
+2. **`time_utils.py`**: All temporal utilities
+   - Existing: `timestamp_to_seconds()`, `seconds_to_timestamp()`
+   - Existing: `format_video_published()`, `format_video_duration()`
+
+3. **`xml_builder.py`**: Enhanced with metadata support
+   - Accepts `VideoMetadata` and `list[Chapter]`
+   - Handles all formatting (dates, durations, timestamps)
+   - Maintains 100% backward compatibility
+
+## 4. Recommended PRs in Logical Order
+
+### PR 1: `feat/shared-models-with-file-integration`
+
+**PR Contents:**
+1. **Create shared models** (`src/youtube_to_xml/models.py`):
+   - `VideoMetadata` class with defaults (video_duration=0 for file method)
+   - `TranscriptLine` class (timestamp: float, text: str)
+   - `Chapter` class with `transcript_lines: list[TranscriptLine]`
+   - Import `math` for `math.inf` support
+   - Factory method `VideoMetadata.empty()` returns instance with all defaults
+
+2. **Refactor file_parser.py to use models**:
+   - Import `TranscriptLine`, `Chapter` from `models.py`
+   - Remove local `Chapter` definition (lines 30-42)
+   - Update `_extract_transcript_lines_for_chapters()` to parse strings into `TranscriptLine` objects
+   - Parse embedded timestamps: `"0:03\nText"` → `TranscriptLine(timestamp=3.0, text="Text")`
+   - Each line with timestamp becomes a `TranscriptLine` object
+   - Lines without timestamps remain as text in subsequent `TranscriptLine` objects
+
+**TDD: Create New Tests (`tests/test_models.py`):**
+- `test_video_metadata_creation_with_defaults()`
+- `test_video_metadata_empty_factory()`
+- `test_transcript_line_creation()`
+- `test_chapter_creation_with_transcript_lines()`
+- `test_chapter_duration_calculation()`
+- `test_models_are_frozen_dataclasses()`
+
+**TDD: Update Existing Tests (`tests/test_file_parser.py`):**
+- Import `Chapter`, `TranscriptLine` from models
+- Update assertions to check for `TranscriptLine` objects
+- Add `test_parses_strings_to_transcript_lines()`
+- Add `test_extracts_timestamp_from_line_start()`
+- Verify chapter.transcript_lines contains `TranscriptLine` objects
+
+**Value:** Models + immediate integration, no dead code, file parser gains type safety
+**Risk:** Medium - significant refactoring but comprehensive test coverage ensures safety
+**Dependencies:** None
+
+### PR 3: `refactor/xml-builder-metadata-support`
+
+**PR Contents:**
+- Import `VideoMetadata`, `Chapter`, `TranscriptLine` from `models.py`
+- Change signature: `chapters_to_xml(chapters: list[Chapter], metadata: VideoMetadata | None = None)`
+- If metadata is None, use `VideoMetadata.empty()` for backward compatibility
+- Format metadata fields with special handling:
+  - `video_duration`: If 0 → `""`, else format seconds → "2h 15m"
+  - `video_published`: If empty → `""`, else YYYYMMDD → "YYYY-MM-DD"
+- Format `TranscriptLine` objects into timestamped text
+- Update CLI to pass `VideoMetadata.empty()` when calling xml_builder
+
+**TDD: Update Existing Tests:**
+- Add metadata parameter to test calls (can be None initially)
+- Verify backward compatibility with None metadata
+
+**TDD: Create New Tests:**
+- `test_formats_transcript_lines_from_objects()`
+- `test_formats_metadata_fields()`
+- `test_formats_zero_duration_as_empty_string()`
+- `test_formats_positive_duration_as_human_readable()`
+- `test_backward_compatibility_with_none_metadata()`
+
+**Value:** Enables rich metadata, unified XML generation, maintains 100% compatibility
+**Risk:** Medium - changes core functionality but maintains backward compatibility
+**Dependencies:** PR 1 must be completed first
+
+### PR 3: `refactor/url-script-shared-models`
+
+**PR Contents:**
+- Import `VideoMetadata`, `TranscriptLine`, `Chapter` from `models.py`
+- Remove local definitions of these classes
+- Update `VideoMetadata` creation to use raw values:
+  - `video_duration`: Store as integer seconds (not formatted string)
+  - `video_published`: Store as YYYYMMDD (not formatted)
+- Remove `format_transcript_lines()` method from local Chapter
+- Remove duplicate XML generation (`create_xml_document()`, `format_xml_output()`)
+- Use shared `xml_builder.chapters_to_xml()` instead
+- Update `convert_youtube_to_xml()` to return shared Chapter objects
+
+**TDD: Update Existing Tests:**
+- Import models from shared module
+- Verify URL script produces same XML output using shared xml_builder
+
+**Value:** Completes integration, eliminates all duplication, single source of truth
+**Risk:** Medium - significant refactoring of URL script, but isolated from main app
+**Dependencies:** PRs 1 and 2 must be completed first
+
+## 5. Testing Strategy
+
+### Test Coverage Requirements
+
+Each PR must:
+1. Pass all existing tests (100% backward compatibility)
+2. Add tests for new functionality (TDD approach)
+3. Update imports where models move to shared module
+4. Verify `test_end_to_end.py` produces identical XML
+
+**Note:** PR 1 combines model creation with file parser integration to ensure no dead code
+
+### Critical Test Files to Monitor
+- `test_file_parser.py` - Updated in PR 1 for model imports and TranscriptLine assertions
+- `test_xml_builder.py` - Updated in PR 2 for metadata parameter additions
+- `test_end_to_end.py` - Must produce identical XML output throughout all PRs
+- `test_models.py` (new in PR 1) - Comprehensive model testing
+
+## 6. Risks and Mitigations
+
+### Risk: Breaking XML Output Format
+**Mitigation:**
+- `assert_files_identical()` in tests ensures exact match
+- Incremental changes with tests at each step
+- Backward compatibility maintained throughout
+
+### Risk: Complex TranscriptLine Migration
+**Mitigation:**
+- PR 1 combines models with file_parser to prove the approach works
+- PR 2 handles the presentation layer separately
+- Each PR is independently valuable and testable
+
+### Risk: Circular Dependencies
+**Mitigation:**
+- models.py has no imports from other app modules
+- Clear dependency hierarchy enforced
+- time_utils remains independent utility module
+
+## 7. Benefits of This Approach
+
+### Immediate Benefits
+- ✅ **Type safety**: Structured data prevents errors
+- ✅ **DRY principle**: No duplicate code or data structures
+- ✅ **Testability**: Each PR delivers working, testable functionality
+- ✅ **Compatibility**: 100% backward compatible
+
+### Long-term Benefits
+- ✅ **Extensibility**: Easy to add new metadata fields
+- ✅ **Maintainability**: Single source of truth for each component
+- ✅ **Flexibility**: Clean separation enables future enhancements
+- ✅ **Source-agnostic**: Both file and URL methods produce identical structures
+
+## Conclusion
+
+This refined approach delivers integration through 3 focused PRs, each providing immediate value while maintaining system stability. By using structured `TranscriptLine` objects throughout, we achieve type safety and source-agnostic processing. The phased approach ensures each PR is manageable, testable, and delivers working functionality without dead code.
+
+**Next Action:** Begin with PR 1 to create shared models and integrate with file parser, establishing the foundation for unified data structures.

--- a/xNEXT.md
+++ b/xNEXT.md
@@ -68,7 +68,7 @@ Per `docs/terminology.md`, transcript lines are defined as timestamp + text pair
 
 ### High-Level Design
 
-```
+```text
                     ┌─────────────────────┐
                     │     models.py       │
                     │  ┌───────────────┐  │
@@ -112,19 +112,19 @@ Per `docs/terminology.md`, transcript lines are defined as timestamp + text pair
 
 1. **`models.py`**: Unified data structures
    ```python
-   @dataclass
+   @dataclass(frozen=True)
    class VideoMetadata:
        video_title: str = ""
        video_published: str = ""  # YYYYMMDD raw format or empty
        video_duration: int = 0      # seconds (0 for file method)
        video_url: str = ""
 
-   @dataclass
+   @dataclass(frozen=True)
    class TranscriptLine:
        timestamp: float  # seconds
        text: str
 
-   @dataclass
+   @dataclass(frozen=True)
    class Chapter:
        title: str
        start_time: float
@@ -133,8 +133,8 @@ Per `docs/terminology.md`, transcript lines are defined as timestamp + text pair
    ```
 
 2. **`time_utils.py`**: All temporal utilities
-   - Existing: `timestamp_to_seconds()`, `seconds_to_timestamp()`
-   - Existing: `format_video_published()`, `format_video_duration()`
+   - Provided by time_utils.py: `timestamp_to_seconds()`, `seconds_to_timestamp()`
+   - Provided by time_utils.py: `format_video_published()`, `format_video_duration()`
 
 3. **`xml_builder.py`**: Enhanced with metadata support
    - Accepts `VideoMetadata` and `list[Chapter]`
@@ -180,7 +180,7 @@ Per `docs/terminology.md`, transcript lines are defined as timestamp + text pair
 **Risk:** Medium - significant refactoring but comprehensive test coverage ensures safety
 **Dependencies:** None
 
-### PR 3: `refactor/xml-builder-metadata-support`
+### PR 2: `refactor/xml-builder-metadata-support`
 
 **PR Contents:**
 - Import `VideoMetadata`, `Chapter`, `TranscriptLine` from `models.py`


### PR DESCRIPTION
## Summary
- Centralise video metadata formatting functions in time_utils module
- Rename XML transcript attributes to use video_ prefix for clarity
- Add comprehensive integration analysis roadmap reflecting completed work

## Test plan
- [x] All existing tests pass with updated attribute names
- [x] Centralised formatting functions maintain identical behaviour  
- [x] XML examples updated to reflect new attribute naming convention
- [x] Integration analysis updated to reflect current state

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - XML output now uses video_published and video_duration metadata; durations shown in human-readable form (e.g., "1h 5m 12s").

- **Documentation**
  - README and sample transcripts updated to reflect new attribute names.
  - Added Integration Analysis Report outlining future architecture.

- **Tests**
  - Added/updated tests for date and duration formatting; test count increased to 78 and runtime improved (~59s).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->